### PR TITLE
🐛 Fix color name in bliss.vim

### DIFF
--- a/.vim/colors/bliss.vim
+++ b/.vim/colors/bliss.vim
@@ -144,7 +144,7 @@ endif
 " Theme setup
 hi clear
 syntax reset
-let g:colors_name = "tomorrow"
+let g:colors_name = "bliss"
 
 " Highlighting function
 " Optional variables are attributes and guisp


### PR DESCRIPTION
The `bliss.vim` file contains the line `let g:colors_name = "tomorrow"`. This causes the colorscheme to be identified as tomorrow (you can see that by issuing `:colors` after setting the colorscheme via `:colors bliss`). This PR sets the color name variable to `bliss`, so that the colorscheme can be identified correctly.